### PR TITLE
AssumeVariableHeights

### DIFF
--- a/Editors/TextCellEditor.cs
+++ b/Editors/TextCellEditor.cs
@@ -97,7 +97,7 @@ namespace XPTable.Editors
                 return;
             }
 
-            this.TextBox.Multiline = this.EditingTable.EnableWordWrap && this.EditingCell.WordWrap;
+            this.TextBox.Multiline = (this.EditingTable.EnableWordWrap || EditingTable.AssumeVariableHeights) && this.EditingCell.WordWrap;
 
             this.TextBox.KeyPress += this.OnKeyPress;
             this.TextBox.LostFocus += this.OnLostFocus;

--- a/Models/DragDropHelper.cs
+++ b/Models/DragDropHelper.cs
@@ -82,6 +82,10 @@ namespace XPTable.Models
                         return;
                     }
 
+//System.Diagnostics.Debug.WriteLine(string.Format("Dragging row = {0} target drop row = {1}", data.table.SelectedItems[0].Index, nRow));
+					if(data.table.SelectedItems[0].Index == nRow)	//don't move a row that isn't actually moving
+						return;
+
                     if (data.table != null)
                     {
                         if (data.table.SelectedIndicies.GetLength(0) > 0)

--- a/Models/Row.cs
+++ b/Models/Row.cs
@@ -890,7 +890,24 @@ namespace XPTable.Models
                 else
                     return this.height;
             }
-            set { this.height = value; }
+            set
+			{
+				if(value >= 0 && TableModel != null && TableModel.Table != null)
+					this.TableModel.Table.AssumeVariableHeights = false;
+				this.height = value;
+			}
+        }
+
+		/// <summary>
+        /// HACK to use actual row heights when the user overrides them
+        /// </summary>
+        [Browsable(false)]
+        public bool IsUsingFixedHeight
+        {
+            get
+            {
+                return (this.height < 0);
+            }
         }
 
 		/// <summary>

--- a/Models/RowCollection.cs
+++ b/Models/RowCollection.cs
@@ -108,7 +108,10 @@ namespace XPTable.Models
 
             if (owner != null)
             {
-                // this RowCollection is the collection of toplevel rows
+				if(!row.IsUsingFixedHeight)
+					this.owner.Table.AssumeVariableHeights = true;
+
+				// this RowCollection is the collection of toplevel rows
                 this.OnRowAdded(new TableModelEventArgs(this.owner, row, index, index));
             }
             else if (rowowner != null)

--- a/Models/Table.cs
+++ b/Models/Table.cs
@@ -770,6 +770,8 @@ namespace XPTable.Models
         private bool enableWordWrap;
         #endregion
 
+		private bool assumeFixedHeight = false;
+
         /// <summary>
         /// Helper class that provides all drag drop functionality.
         /// </summary>
@@ -920,7 +922,7 @@ namespace XPTable.Models
         {
             int yOffset;
             // This adds on the total height we can't see
-            if (this.EnableWordWrap)
+            if (this.EnableWordWrap || AssumeVariableHeights)
             {
                 yOffset = this.RowY(this.TopIndex);
             }
@@ -1775,7 +1777,7 @@ namespace XPTable.Models
 
             rect.X = this.DisplayRectangle.X;
 
-            if (this.EnableWordWrap)
+            if (this.EnableWordWrap || AssumeVariableHeights)
             {
                 rect.Y = this.BorderWidth + this.RowYDifference(this.TopIndex, row);
                 rect.Height = this.TableModel.Rows[row].Height;
@@ -2479,7 +2481,7 @@ namespace XPTable.Models
 
                 this.ColumnModel.Columns.RecalcWidthCache();
 
-                if (this.EnableWordWrap)
+                if (this.EnableWordWrap || AssumeVariableHeights)
                 {
                     if (autoCalculateRowHeights)
                         this.CalculateAllRowHeights();
@@ -4158,7 +4160,7 @@ namespace XPTable.Models
                 // v1.1.1 fix (jover) - used to error if no rows were added
                 if (this.TableModel == null || this.TableModel.Rows.Count == 0)
                     return 0;
-                else if (this.EnableWordWrap)
+                else if (this.EnableWordWrap || AssumeVariableHeights)
                     return this.RowYDifference(0, this.TableModel.Rows.Count);
                 else
                     return this.TableModel.Rows.Count * this.RowHeight;
@@ -4201,7 +4203,7 @@ namespace XPTable.Models
         public int GetVisibleRowCount()
         {
             int count;
-            if (this.EnableWordWrap)
+            if (this.EnableWordWrap || AssumeVariableHeights)
                 count = this.VisibleRowCountExact();
             else
                 count = this.CellDataRect.Height / this.RowHeight;
@@ -5010,6 +5012,18 @@ namespace XPTable.Models
             set { enableWordWrap = value; }
         }
         #endregion
+
+        /// <summary>
+        /// Gets of sets whether word wrap is allowed in any cell in the table. If false then the WordWrap property on Cells is ignored.
+        /// </summary>
+        [Category("Behavior"),
+        DefaultValue(false),
+        Description("Hint to GUI rendering and hit detection (optimization) to calculate row heights")]
+        public bool AssumeVariableHeights
+        {
+            get { return assumeFixedHeight; }
+            set { assumeFixedHeight = value; }
+        }
 
         #region ToolTips
         /// <summary>
@@ -8834,7 +8848,7 @@ namespace XPTable.Models
 
             this.Invalidate();
 
-            if (this.EnableWordWrap)
+            if (this.EnableWordWrap || AssumeVariableHeights)
                 UpdateScrollBars();
 
             lastVScrollValue = vScrollBar.Value;

--- a/Models/TableModel.cs
+++ b/Models/TableModel.cs
@@ -184,7 +184,7 @@ namespace XPTable.Models
         public int RowIndexAt(int yPosition)
         {
             int row;
-            if (this.Table.EnableWordWrap)
+            if (this.Table.EnableWordWrap || this.Table.AssumeVariableHeights)
             {
                 row = this.RowIndexAtExact(yPosition);
             }
@@ -1287,7 +1287,7 @@ namespace XPTable.Models
                 if (this.owner.Table != null && this.owner.Table.ColumnModel != null)
                     bounds.Width = this.owner.Table.ColumnModel.VisibleColumnsWidth;
 
-                if (this.owner.Table.EnableWordWrap)
+                if (this.owner.Table.EnableWordWrap || owner.Table.AssumeVariableHeights)
                 {
                     // v1.1.1 fix - this Y value used to include the border + header height
 

--- a/Models/TableModel.cs
+++ b/Models/TableModel.cs
@@ -1322,5 +1322,24 @@ namespace XPTable.Models
             #endregion
         }
         #endregion
+
+		/// <summary>search given column for given text the collection of selected Rows and Cells in a TableModel</summary>
+		public Row FindRow(int column, string text, bool caseSensitive)
+		{
+			Row retval = null;
+			foreach(Row row in rows)
+			{
+				if(row.Cells.Count > column)
+				{
+					if((row.Cells[column].Text != null) && (row.Cells[column].Text.Equals(text, caseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase)))
+					{
+						retval = row;
+						break;
+					}
+				}
+			}
+			return retval;
+		}
+
     }
 }


### PR DESCRIPTION
HACK: Table does not account for a user setting one or more row heights - I consider this a hack because I am piggybacking on EnableWordWrap. I prefer the hack to duplicating the code, and the underlying issue (drawing and clicking a row) is the same for both.
