### PR TITLE
Fix #38 - Reworked SendMessage and PostMessage pinvokes

### DIFF
--- a/Editors/DropDownCellEditor.cs
+++ b/Editors/DropDownCellEditor.cs
@@ -705,7 +705,7 @@ namespace XPTable.Editors
                     {
                         if (((int)m.WParam) == 0)
                         {
-                            NativeMethods.SendMessage(this.Handle, (int)WindowMessage.WM_NCACTIVATE, 1, 0);
+                            NativeMethods.SendMessage(this.Handle, (int)WindowMessage.WM_NCACTIVATE, new IntPtr(1), IntPtr.Zero);
                         }
                     }
                     else if (m.Msg == (int)WindowMessage.WM_ACTIVATEAPP)
@@ -714,7 +714,7 @@ namespace XPTable.Editors
                         {
                             this.owner.DroppedDown = false;
 
-                            NativeMethods.PostMessage(this.Handle, (int)WindowMessage.WM_NCACTIVATE, 0, 0);
+                            NativeMethods.PostMessage(this.Handle, (int)WindowMessage.WM_NCACTIVATE, IntPtr.Zero, IntPtr.Zero);
                         }
                     }
                 }

--- a/Models/Table.cs
+++ b/Models/Table.cs
@@ -2506,7 +2506,7 @@ namespace XPTable.Models
             if (this.IsHandleCreated)
             {
                 if (this.beginUpdateCount == 0)
-                    NativeMethods.SendMessage(this.Handle, 11, 0, 0);
+                    NativeMethods.SendMessage(this.Handle, 11, IntPtr.Zero, IntPtr.Zero);
 
                 this.beginUpdateCount++;
             }
@@ -2525,7 +2525,7 @@ namespace XPTable.Models
 
             if (this.beginUpdateCount == 0)
             {
-                NativeMethods.SendMessage(this.Handle, 11, -1, 0);
+                NativeMethods.SendMessage(this.Handle, 11, new IntPtr(-1), IntPtr.Zero);
 
                 this.PerformLayout();
 

--- a/Win32/NativeMethods.cs
+++ b/Win32/NativeMethods.cs
@@ -51,10 +51,10 @@ namespace XPTable.Win32
 		/// <param name="lParam">Specifies additional message-specific information</param>
 		/// <returns>The return value specifies the result of the message processing; 
 		/// it depends on the message sent</returns>
-		[DllImport("User32.dll", CharSet=CharSet.Auto, SetLastError=true)] 
-		internal static extern int SendMessage(IntPtr hwnd, int msg, int wParam, int lParam);
+		[DllImport("User32.dll", CharSet=CharSet.Auto, SetLastError=true)]
+		internal static extern IntPtr SendMessage( IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam );
 
-
+		
 		/// <summary>
 		/// The TrackMouseEvent function posts messages when the mouse pointer 
 		/// leaves a window or hovers over a window for a specified amount of time
@@ -78,8 +78,8 @@ namespace XPTable.Win32
 		/// <param name="lparam">Specifies additional message-specific information</param>
 		/// <returns>If the function succeeds, the return value is nonzero. If the function 
 		/// fails, the return value is zero</returns>
-		[DllImport("User32.dll", CharSet=CharSet.Auto, SetLastError=true)]
-		internal static extern IntPtr PostMessage(IntPtr hwnd, int msg, int wparam, int lparam);
+		[DllImport( "User32.dll", CharSet = CharSet.Auto, SetLastError = true )]
+		internal static extern IntPtr PostMessage( IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam );
 
 
 		/// <summary>


### PR DESCRIPTION
Fix for issue #38 - The SendMessage and PostMessage pinvokes don't have
the proper signatures. `wParam` and `lParam` should be declared as
IntPtrs since their size is 32-bit/64-bit depending on the platform.
SendMessage's `LRESULT` return type should also be modeled as such.
These bad declarations can cause the stack to become unbalanced, causing
a crash. However, it seems that these were still working by the skin of
their teeth due to how these values are handled under 64-bit calling
conventions - they're passed in registers in 64-bit, and passed on the
stack (iirc) in 32-bit. Because the values were always 32-bit but they
they're not passed on the stack in 64-bit, there's no stack to
unbalance, so it didn't crash.